### PR TITLE
Updated SnakeBossState Address

### DIFF
--- a/BRC.asl
+++ b/BRC.asl
@@ -4,7 +4,7 @@ BOMB RUSH CYBERFUNK AUTOSPLITTER (PC)
 -------------------------------------
 
 Created by: Austin 'Auddy' Davenport and Loomeh
-Special thanks to: kitcarsonn, Christian Royle, Helix13, YellowBoy and Sooldy
+Special thanks to: Ninja Cookie, kitcarsonn, Christian Royle, Helix13, YellowBoy and Sooldy
 */
 
 
@@ -54,7 +54,7 @@ state("Bomb Rush Cyberfunk")
 	// Version 1.0.19864 (patch 1 8/30/2023)
 	byte stageID : "UnityPlayer.dll", 0x01ADBA40, 0x30, 0x50, 0x28, 0x28, 0x70, 0x10, 0xBC;
 	byte objectiveID : "UnityPlayer.dll", 0x01ADBA40, 0x30, 0x50, 0x28, 0x90, 0x70, 0x28, 0x58;
-	byte SnakeBossState : "UnityPlayer.dll", 0x01B4AC20, 0x0, 0x88, 0x60, 0x20, 0x40, 0x10, 0x20, 0x2E4;
+	byte SnakeBossState : "UnityPlayer.dll", 0x01A79540, 0x0, 0x700, 0x568, 0x5D8, 0xD8, 0x20, 0x78, 0x650, 0x20, 0x2E4;
 	bool loading : "UnityPlayer.dll", 0x01ADBA40, 0x68, 0x20, 0x140, 0x0, 0x120, 0x30, 0x57;
 	bool inCutscene : "UnityPlayer.dll", 0x01A8DFC0, 0x28, 0x18, 0x18, 0x18, 0x10, 0x2A8;
 }
@@ -141,14 +141,14 @@ startup
 start
 {
 	// Settings for New Game start Any%
-	if(current.stageID == 8 && (current.inCutscene && old.loading) && settings["Any"])
+	if((current.stageID == 8 && (current.inCutscene && old.loading)) && settings["Any"])
 	{
 		vars.gameMode = 1;	// Set game mode
 		return true;
 	}
 	
 	// Settings for New Game start Glitchless
-	if(current.stageID == 8 && (current.inCutscene && old.loading) && settings["Glitchless"])
+	if((current.stageID == 8 && (current.inCutscene && old.loading)) && settings["Glitchless"])
 	{
 		vars.gameMode = 2;	// Set game mode
 		return true;
@@ -195,7 +195,7 @@ split
 	||
 	((current.stageID == 5 && old.stageID == 9 && current.objectiveID == 11) && settings["chapter4Any"])
 	||
-	((current.stageID == 7 && (current.objectiveID == 11 || current.objectiveID == 13) && current.SnakeBossState == 8) && settings["finalAny"]))
+	((current.stageID == 7 && (current.objectiveID == 11 || current.objectiveID == 13) && current.SnakeBossState == 8 && old.SnakeBossState != 8) && settings["finalAny"]))
 	{
 		return true;
 	}
@@ -236,7 +236,7 @@ split
 	||
 	((current.stageID == 7 && current.objectiveID == 13 && old.objectiveID == 12) && settings["endgameGlitchless"])
 	||
-	((current.stageID == 7 && (current.objectiveID == 11 || current.objectiveID == 13) && current.SnakeBossState == 8) && settings["finalGlitchless"]))
+	((current.stageID == 7 && (current.objectiveID == 11 || current.objectiveID == 13) && current.SnakeBossState == 8 && old.SnakeBossState != 8) && settings["finalGlitchless"]))
 	{
 		return true;
 	}
@@ -250,7 +250,7 @@ isLoading
 reset
 {
 	// Reset if we go to Prologue from Main Menu
-	if((current.stageID == 8) && (current.inCutscene && old.loading))
+	if(current.stageID == 8 && (current.inCutscene && old.loading))
 	{
 		vars.gameMode = 0;
 		return true;


### PR DESCRIPTION
Possible fix for final boss split, with an updated address for SnakeBossState, which has worked on multiple installs and PC's, and has worked from start to end in a single full run. Also has some other small code changes related to the split its-self.

Either it works, or it does nothing different than it already was, so worth pushing.