### PR TITLE
Timer Resume at Menu, Added Splits, Fixes, and general clean up.

### DIFF
--- a/BRC.asl
+++ b/BRC.asl
@@ -68,175 +68,224 @@ init
 startup
 {
 	refreshRate = 200;
-
-	settings.CurrentDefaultParent = null;
-	settings.Add("gameMode", true, "Game Modes");
-	settings.SetToolTip("gameMode", "Do not uncheck this box");
+	vars.splashOver = true;
 	
 	// Any%
-	settings.CurrentDefaultParent = "gameMode";
+	settings.CurrentDefaultParent = null;
 	settings.Add("Any", true, "Any%");
 	settings.SetToolTip("Any", "Check this Option if you want to run Any%");
 	
-	settings.CurrentDefaultParent = "Any";
-	settings.Add("splitsAny", true, "Autosplitter");
-	settings.SetToolTip("splitsAny", "Check this Option if you want to use the Autosplitting feature.  You can choose your Splits below");
+		// Chapter 1
+		settings.CurrentDefaultParent = "Any";
+		settings.Add("chapter1AnyTool", true, "Chapter 1 Splits");
 	
-	settings.CurrentDefaultParent = "splitsAny";
-	settings.Add("stagesAny", true, "Stages");
-	settings.SetToolTip("stagesAny", "Check this Option if you want to Autosplit on Stages");
+			settings.CurrentDefaultParent = "chapter1AnyTool";
+			settings.Add("prologueAny",true,"Prologue End");
+			settings.Add("hideoutEscape",false,"Mataan Start");
+			settings.Add("hideoutAny",true,"Versum Hill Start");
+			settings.Add("versumAny",true,"Dream Sequence 1 Start");
+			settings.Add("chapter1Any",true,"Chapter 1 End");
+		
+		// Chapter 2
+		settings.CurrentDefaultParent = "Any";
+		settings.Add("chapter2AnyTool", true, "Chapter 2 Splits");
 	
-	settings.CurrentDefaultParent = "stagesAny";
-	settings.Add("prologueAny",true,"Prologue End / Hideout Start");
-	settings.Add("hideoutAny",true,"Hideout Tutorial End / Versum Start");
-	settings.Add("versumAny",true,"Versum Hill End / Dream Sequence 1 Start");
-	settings.Add("chapter1Any",true,"Chapter 1 End");
-	settings.Add("squareAny",true,"Millennium Square End / Brink Terminal Start");
-	settings.Add("brinkAny",true,"Brink Terminal End / Dream Sequence 2 Start");
-	settings.Add("chapter2Any",true,"Chapter 2 End");
-	settings.Add("mallAny",true,"Millennium Mall End / Dream Sequence 3 Start");
-	settings.Add("chapter3Any",true,"Chapter 3 End");
-	settings.Add("prince1Any",false,"Flesh Prince Versum End");
-	settings.Add("prince2Any",false,"Flesh Prince Millennium End");
-	settings.Add("prince3Any",false,"Flesh Prince Brink End");
-	settings.Add("prince4Any",false,"Flesh Prince Mataan End / Pyramid Island Start");
-	settings.Add("pyramidAny",true,"Pyramid Island End / Dream Sequence 4 Start");
-	settings.Add("chapter4Any",true,"Chapter 4 End");
-	settings.Add("finalAny",true,"Final Boss");
+			settings.CurrentDefaultParent = "chapter2AnyTool";
+			settings.Add("squareAny",true,"Brink Terminal Start");
+			settings.Add("brinkAny",true,"Dream Sequence 2 Start");
+			settings.Add("chapter2Any",true,"Chapter 2 End");
+		
+		// Chapter 3
+		settings.CurrentDefaultParent = "Any";
+		settings.Add("chapter3AnyTool", true, "Chapter 3 Splits");
+	
+			settings.CurrentDefaultParent = "chapter3AnyTool";
+			settings.Add("enterMallAny",true,"Millennium Mall Start");
+			settings.Add("mallAny",true,"Dream Sequence 3 Start");
+			settings.Add("chapter3Any",true,"Chapter 3 End");
+	
+		// Chapter 4
+		settings.CurrentDefaultParent = "Any";
+		settings.Add("chapter4AnyTool", true, "Chapter 4 Splits");
+	
+			settings.CurrentDefaultParent = "chapter4AnyTool";
+			settings.Add("prince1Any",false,"Flesh Prince Versum End");
+			settings.Add("prince2Any",false,"Flesh Prince Millennium End");
+			settings.Add("prince3Any",false,"Flesh Prince Brink End");
+			settings.Add("prince4Any",false,"Pyramid Island Start");
+			settings.Add("pyramidAny",true,"Dream Sequence 4 Start");
+			settings.Add("chapter4Any",true,"Chapter 4 End");
+	
+		// Chapter 5
+		settings.CurrentDefaultParent = "Any";
+		settings.Add("chapter5AnyTool", true, "Chapter 5 Splits");
+	
+			settings.CurrentDefaultParent = "chapter5AnyTool";
+			settings.Add("finalAny",true,"Final Boss Defeated");
 	
 	// Glitchless
-	settings.CurrentDefaultParent = "gameMode";
+	settings.CurrentDefaultParent = null;
 	settings.Add("Glitchless", false, "Glitchless");
-	settings.SetToolTip("Glitchless", "Check this Option if you want to run Glitchless");
+	settings.SetToolTip("Glitchless", "Check this Option if you want to run Any% Glitchless");
 	
-	settings.CurrentDefaultParent = "Glitchless";
-	settings.Add("splitsGlitchless", true, "Autosplitter");
-	settings.SetToolTip("splitsGlitchless", "Check this Option if you want to use the Autosplitting feature.  You can choose your Splits below");
+		// Chapter 1
+		settings.CurrentDefaultParent = "Glitchless";
+		settings.Add("chapter1GlitchlessTool", true, "Chapter 1 Splits");
 	
-	settings.CurrentDefaultParent = "splitsGlitchless";
-	settings.Add("stagesGlitchless", true, "Stages");
-	settings.SetToolTip("stagesGlitchless", "Check this Option if you want to Autosplit on Stages");
+			settings.CurrentDefaultParent = "chapter1GlitchlessTool";
+			settings.Add("prologueGlitchless",false,"Prologue End");
+			settings.Add("hideoutGlitchless",false,"Versum Hill Start");
+			settings.Add("versumGlitchless",false,"Dream Sequence 1 Start");
+			settings.Add("chapter1Glitchless",true,"Chapter 1 End");
+		
+		// Chapter 2
+		settings.CurrentDefaultParent = "Glitchless";
+		settings.Add("chapter2GlitchlessTool", true, "Chapter 2 Splits");
 	
-	settings.CurrentDefaultParent = "stagesGlitchless";
-	settings.Add("prologueGlitchless",false,"Prologue End / Hideout Start");
-	settings.Add("hideoutGlitchless",false,"Hideout Tutorial End / Versum Start");
-	settings.Add("versumGlitchless",false,"Versum Hill End / Dream Sequence 1 Start");
-	settings.Add("chapter1Glitchless",true,"Chapter 1 End");
-	settings.Add("squareGlitchless",false,"Millennium Square End / Brink Terminal Start");
-	settings.Add("brinkGlitchless",false,"Brink Terminal End / Dream Sequence 2 Start");
-	settings.Add("chapter2Glitchless",true,"Chapter 2 End");
-	settings.Add("mallGlitchless",false,"Millennium Mall End / Dream Sequence 3 Start");
-	settings.Add("chapter3Glitchless",true,"Chapter 3 End");
-	settings.Add("prince1Glitchless",false,"Flesh Prince Versum End");
-	settings.Add("prince2Glitchless",false,"Flesh Prince Millennium End");
-	settings.Add("prince3Glitchless",false,"Flesh Prince Brink End");
-	settings.Add("prince4Glitchless",false,"Flesh Prince Mataan End / Pyramid Island Start");
-	settings.Add("pyramidGlitchless",false,"Pyramid Island End / Dream Sequence 4 Start");
-	settings.Add("chapter4Glitchless",true,"Chapter 4 End");
-	settings.Add("mataanGlitchless",true,"Mataan End / Dream Sequence 5 Start");
-	settings.Add("endgameGlitchless",true,"Dream Sequence 5 End / Endgame Start");
-	settings.Add("finalGlitchless",true,"Final Boss");
+			settings.CurrentDefaultParent = "chapter2GlitchlessTool";
+		settings.Add("squareGlitchless",false,"Brink Terminal Start");
+		settings.Add("brinkGlitchless",false,"Dream Sequence 2 Start");
+		settings.Add("chapter2Glitchless",true,"Chapter 2 End");
+		
+		// Chapter 3
+		settings.CurrentDefaultParent = "Glitchless";
+		settings.Add("chapter3GlitchlessTool", true, "Chapter 3 Splits");
+	
+			settings.CurrentDefaultParent = "chapter3GlitchlessTool";
+			settings.Add("enterMallGlitchless",false,"Millennium Mall Start");
+			settings.Add("mallGlitchless",false,"Dream Sequence 3 Start");
+			settings.Add("chapter3Glitchless",true,"Chapter 3 End");
+			
+		// Chapter 4
+		settings.CurrentDefaultParent = "Glitchless";
+		settings.Add("chapter4GlitchlessTool", true, "Chapter 4 Splits");
+	
+			settings.CurrentDefaultParent = "chapter4GlitchlessTool";
+			settings.Add("prince1Glitchless",false,"Flesh Prince Versum End");
+			settings.Add("prince2Glitchless",false,"Flesh Prince Millennium End");
+			settings.Add("prince3Glitchless",false,"Flesh Prince Brink End");
+			settings.Add("prince4Glitchless",false,"Pyramid Island Start");
+			settings.Add("pyramidGlitchless",false,"Dream Sequence 4 Start");
+			settings.Add("chapter4Glitchless",true,"Chapter 4 End");
+			
+		// Chapter 5
+		settings.CurrentDefaultParent = "Glitchless";
+		settings.Add("chapter5GlitchlessTool", true, "Chapter 5 Splits");
+	
+			settings.CurrentDefaultParent = "chapter5GlitchlessTool";
+			settings.Add("mataanGlitchless",true,"Dream Sequence 5 Start");
+			settings.Add("endgameGlitchless",true,"Endgame Start");
+			settings.Add("finalGlitchless",true,"Final Boss Defeated");
 }
 
 start
 {
 	// Settings for New Game start Any%
-	if((current.stageID == 8 && (current.inCutscene && old.loading)) && settings["Any"])
+	if(settings["Any"] && (current.stageID == 8 && (current.inCutscene && (old.loading && !current.loading))))
 	{
 		vars.gameMode = 1;	// Set game mode
+		vars.splashOver = true;
 		return true;
 	}
 	
 	// Settings for New Game start Glitchless
-	if((current.stageID == 8 && (current.inCutscene && old.loading)) && settings["Glitchless"])
+	if(settings["Glitchless"] && (current.stageID == 8 && (current.inCutscene && (old.loading && !current.loading))))
 	{
 		vars.gameMode = 2;	// Set game mode
+		vars.splashOver = true;
 		return true;
 	}
 }
 
 split
 {
+	
 	// Any%
-	if((vars.gameMode == 1) &&
-	((current.stageID == 5 && old.stageID == 8) && settings["prologueAny"])
+	if((vars.gameMode == 1) 	&&
+	(settings["prologueAny"] 	&& 	(current.stageID == 5 && old.stageID == 8))
 	||
-  	((current.stageID == 7 && old.stageID == 5 && (current.objectiveID == 0 || current.objectiveID == 1)) && settings["hideoutAny"]) // hideout skip
-  	||
-	((current.stageID == 4 && old.stageID == 5 && current.objectiveID == 2) && settings["hideoutAny"])
+	(settings["hideoutEscape"]	&&	((current.stageID == 7 && old.stageID == 5) && (current.objectiveID == 0 || current.objectiveID == 1)))
 	||
-	((current.stageID == 4 && current.objectiveID == 3 && old.objectiveID == 2) && settings["versumAny"])
+	(settings["hideoutAny"]		&&	((current.stageID == 4 && (old.stageID == 5 || old.stageID == 11)) && (current.objectiveID == 0 || current.objectiveID == 1 || current.objectiveID == 2)))
 	||
-	((current.stageID == 4 && current.objectiveID == 3 && old.objectiveID == 0) && settings["versumAny"]) // Additional fix for hideout skip
+	(settings["versumAny"]		&&	(current.stageID == 4 && (current.objectiveID == 3 && old.objectiveID == 2)))
 	||
-	((current.stageID == 5 && old.stageID == 4 && current.objectiveID == 4) && settings["chapter1Any"])
+	(settings["versumAny"]		&&	(current.stageID == 4 && (current.objectiveID == 3 && old.objectiveID == 0))) // Additional fix for hideout skip
 	||
-	((current.stageID == 12 && old.stageID == 11 && current.objectiveID == 5) && settings["squareAny"])
+	(settings["chapter1Any"]	&&	((current.stageID == 5 && old.stageID == 4) && current.objectiveID == 4))
 	||
-	((current.stageID == 12 && current.objectiveID == 6 && old.objectiveID == 5) && settings["brinkAny"])
+	(settings["squareAny"]		&&	((current.stageID == 12 && old.stageID == 11) && current.objectiveID == 5))
 	||
-	((current.stageID == 5 && old.stageID == 12 && current.objectiveID == 7) && settings["chapter2Any"])
+	(settings["brinkAny"]		&&	(current.stageID == 12 && (current.objectiveID == 6 && old.objectiveID == 5)))
 	||
-	((current.stageID == 6 && current.objectiveID == 8 && old.objectiveID == 7) && settings["mallAny"])
+	(settings["chapter2Any"]	&&	((current.stageID == 5 && old.stageID == 12) && current.objectiveID == 7))
 	||
-	((current.stageID == 5 && old.stageID == 6 && current.objectiveID == 15) && settings["chapter3Any"])
+	(settings["enterMallAny"]	&&	((current.stageID == 6 && old.stageID == 11) && current.objectiveID == 7))
 	||
-	((current.stageID == 4 && current.objectiveID == 16 && old.objectiveID == 15) && settings["prince1Any"])
+	(settings["mallAny"]		&&	(current.stageID == 6 && (current.objectiveID == 8 && old.objectiveID == 7)))
 	||
-	((current.stageID == 11 && current.objectiveID == 17 && old.objectiveID == 16) && settings["prince2Any"])
+	(settings["chapter3Any"]	&&	((current.stageID == 5 && old.stageID == 6) && current.objectiveID == 15))
 	||
-	((current.stageID == 12 && current.objectiveID == 18 && old.objectiveID == 17) && settings["prince3Any"])
+	(settings["prince1Any"]		&&	(current.stageID == 4 && (current.objectiveID == 16 && old.objectiveID == 15)))
 	||
-	((current.stageID == 5 && old.stageID == 7 && current.objectiveID == 9) && settings["prince4Any"])
+	(settings["prince2Any"]		&&	(current.stageID == 11 && (current.objectiveID == 17 && old.objectiveID == 16)))
 	||
-	((current.stageID == 9 && current.objectiveID == 10 && old.objectiveID == 9) && settings["pyramidAny"])
+	(settings["prince3Any"]		&&	(current.stageID == 12 && (current.objectiveID == 18 && old.objectiveID == 17)))
 	||
-	((current.stageID == 9 && current.objectiveID == 10 && old.objectiveID == 15) && settings["pyramidAny"]) // Pyramid skip
+	(settings["prince4Any"]		&&	((current.stageID == 5 && old.stageID == 7) && current.objectiveID == 9))
 	||
-	((current.stageID == 5 && old.stageID == 9 && current.objectiveID == 11) && settings["chapter4Any"])
+	(settings["prince4Any"]		&&	((current.stageID == 9 && old.stageID == 11) && (current.objectiveID == 15 || current.objectiveID == 9))) // Fix for early pyramid
 	||
-	((current.stageID == 7 && (current.objectiveID == 11 || current.objectiveID == 13) && current.SnakeBossState == 8 && old.SnakeBossState != 8) && settings["finalAny"]))
+	(settings["pyramidAny"]		&&	(current.stageID == 9 && (current.objectiveID == 10 && old.objectiveID == 9)))
+	||
+	(settings["pyramidAny"]		&&	(current.stageID == 9 && (current.objectiveID == 10 && old.objectiveID == 15))) // Pyramid skip
+	||
+	(settings["chapter4Any"]	&&	((current.stageID == 5 && old.stageID == 9) && current.objectiveID == 11))
+	||
+	(settings["finalAny"]		&&	(current.stageID == 7 && (current.objectiveID == 11 || current.objectiveID == 13) && (current.SnakeBossState == 8 && old.SnakeBossState != 8))))
 	{
 		return true;
 	}
 	
 	// Glitchless
-	if((vars.gameMode == 2) &&
-	((current.stageID == 5 && old.stageID == 8) && settings["prologueGlitchless"])
+	if((vars.gameMode == 2) 			&&
+	(settings["prologueGlitchless"]		&&	(current.stageID == 5 && old.stageID == 8))
 	||
-	((current.stageID == 4 && old.stageID == 5 && current.objectiveID == 2) && settings["hideoutGlitchless"])
+	(settings["hideoutGlitchless"] 		&&	((current.stageID == 4 && old.stageID == 5) && current.objectiveID == 2))
 	||
-	((current.stageID == 4 && current.objectiveID == 3 && old.objectiveID == 2) && settings["versumGlitchless"])
+	(settings["versumGlitchless"]		&&	(current.stageID == 4 && (current.objectiveID == 3 && old.objectiveID == 2)))
 	||
-	((current.stageID == 5 && old.stageID == 4 && current.objectiveID == 4) && settings["chapter1Glitchless"])
+	(settings["chapter1Glitchless"]		&&	((current.stageID == 5 && old.stageID == 4) && current.objectiveID == 4))
 	||
-	((current.stageID == 12 && old.stageID == 11 && current.objectiveID == 5) && settings["squareGlitchless"])
+	(settings["squareGlitchless"]		&&	((current.stageID == 12 && old.stageID == 11) && current.objectiveID == 5))
 	||
-	((current.stageID == 12 && current.objectiveID == 6 && old.objectiveID == 5) && settings["brinkGlitchless"])
+	(settings["brinkGlitchless"]		&&	(current.stageID == 12 && (current.objectiveID == 6 && old.objectiveID == 5)))
 	||
-	((current.stageID == 5 && old.stageID == 12 && current.objectiveID == 7) && settings["chapter2Glitchless"])
+	(settings["chapter2Glitchless"]		&&	((current.stageID == 5 && old.stageID == 12) && current.objectiveID == 7))
 	||
-	((current.stageID == 6 && current.objectiveID == 8 && old.objectiveID == 7) && settings["mallGlitchless"])
+	(settings["enterMallGlitchless"]	&&	((current.stageID == 6 && old.stageID == 11) && current.objectiveID == 7))
 	||
-	((current.stageID == 5 && old.stageID == 6 && current.objectiveID == 15) && settings["chapter3Glitchless"])
+	(settings["mallGlitchless"]			&&	(current.stageID == 6 && (current.objectiveID == 8 && old.objectiveID == 7)))
 	||
-	((current.stageID == 4 && current.objectiveID == 16 && old.objectiveID == 15) && settings["prince1Glitchless"])
+	(settings["chapter3Glitchless"]		&&	((current.stageID == 5 && old.stageID == 6) && current.objectiveID == 15))
 	||
-	((current.stageID == 11 && current.objectiveID == 17 && old.objectiveID == 16) && settings["prince2Glitchless"])
+	(settings["prince1Glitchless"]		&&	(current.stageID == 4 && (current.objectiveID == 16 && old.objectiveID == 15)))
 	||
-	((current.stageID == 12 && current.objectiveID == 18 && old.objectiveID == 17) && settings["prince3Glitchless"])
+	(settings["prince2Glitchless"]		&&	(current.stageID == 11 && (current.objectiveID == 17 && old.objectiveID == 16)))
 	||
-	((current.stageID == 5 && old.stageID == 7 && current.objectiveID == 9) && settings["prince4Glitchless"])
+	(settings["prince3Glitchless"]		&&	(current.stageID == 12 && (current.objectiveID == 18 && old.objectiveID == 17)))
 	||
-	((current.stageID == 9 && current.objectiveID == 10 && old.objectiveID == 9) && settings["pyramidGlitchless"])
+	(settings["prince4Glitchless"]		&&	((current.stageID == 5 && old.stageID == 7) && current.objectiveID == 9))
 	||
-	((current.stageID == 5 && old.stageID == 9 && current.objectiveID == 11) && settings["chapter4Glitchless"])
+	(settings["pyramidGlitchless"]		&&	(current.stageID == 9 && (current.objectiveID == 10 && old.objectiveID == 9)))
 	||
-	((current.stageID == 7 && current.objectiveID == 12 && old.objectiveID == 11) && settings["mataanGlitchless"])
+	(settings["chapter4Glitchless"]		&&	((current.stageID == 5 && old.stageID == 9) && current.objectiveID == 11))
 	||
-	((current.stageID == 7 && current.objectiveID == 13 && old.objectiveID == 12) && settings["endgameGlitchless"])
+	(settings["mataanGlitchless"]		&&	(current.stageID == 7 && (current.objectiveID == 12 && old.objectiveID == 11)))
 	||
-	((current.stageID == 7 && (current.objectiveID == 11 || current.objectiveID == 13) && current.SnakeBossState == 8 && old.SnakeBossState != 8) && settings["finalGlitchless"]))
+	(settings["endgameGlitchless"]		&&	(current.stageID == 7 && (current.objectiveID == 13 && old.objectiveID == 12)))
+	||
+	(settings["finalGlitchless"]		&&	(current.stageID == 7 && ((current.objectiveID == 11 || current.objectiveID == 13) && (current.SnakeBossState == 8 && old.SnakeBossState != 8)))))
 	{
 		return true;
 	}
@@ -244,13 +293,21 @@ split
 
 isLoading
 {
+	if (!vars.splashOver)
+	{
+		if (current.loading)
+		{
+			vars.splashOver = true;
+		}
+		return true;
+	}
 	return current.loading;
 }
 
 reset
 {
 	// Reset if we go to Prologue from Main Menu
-	if(current.stageID == 8 && (current.inCutscene && old.loading))
+	if(current.stageID == 8 && (current.inCutscene && (old.loading && !current.loading)))
 	{
 		vars.gameMode = 0;
 		return true;
@@ -260,5 +317,6 @@ reset
 exit
 {
     // pauses the timer if the game crashes
+	vars.splashOver = false;
 	timer.IsGameTimePaused = true;
 }


### PR DESCRIPTION
Tested by: Helix, Vaen, Storied, Bytez, Splatypus, maybe others. No issues reported, all seemed to function.
Worth still testing and reviewing for any issues that might be missed.
Glitchless not tested but is unchanged other than structure.


+ Adds variable "splashOver" which sets to false when the game closes, and is only set to true when it first gets a loading screen, during which time it will return "isLoading" to True, blocking timer from resuming for the time until it reaches menu.

+ Adds Split for Chapter 1 Mataan Entrance and Chapter 3 Mall Entrance. 

+ Fixes Splits for Pyramid Entrance and Versum Hill Entrance.

+ Modified the autosplit menu layout to be more readable.

+ Moved code around to be more readable.