### PR TITLE
Fix for Mataan Enter split not working if you alt+f4 too early

### DIFF
--- a/BRC.asl
+++ b/BRC.asl
@@ -143,9 +143,9 @@ startup
 		settings.Add("chapter2GlitchlessTool", true, "Chapter 2 Splits");
 	
 			settings.CurrentDefaultParent = "chapter2GlitchlessTool";
-		settings.Add("squareGlitchless",false,"Brink Terminal Start");
-		settings.Add("brinkGlitchless",false,"Dream Sequence 2 Start");
-		settings.Add("chapter2Glitchless",true,"Chapter 2 End");
+			settings.Add("squareGlitchless",false,"Brink Terminal Start");
+			settings.Add("brinkGlitchless",false,"Dream Sequence 2 Start");
+			settings.Add("chapter2Glitchless",true,"Chapter 2 End");
 		
 		// Chapter 3
 		settings.CurrentDefaultParent = "Glitchless";
@@ -204,7 +204,7 @@ split
 	if((vars.gameMode == 1) 	&&
 	(settings["prologueAny"] 	&& 	(current.stageID == 5 && old.stageID == 8))
 	||
-	(settings["hideoutEscape"]	&&	((current.stageID == 7 && old.stageID == 5) && (current.objectiveID == 0 || current.objectiveID == 1)))
+	(settings["hideoutEscape"]	&&	((current.stageID == 5 && (current.loading && !old.loading)) && current.objectiveID == 0))
 	||
 	(settings["hideoutAny"]		&&	((current.stageID == 4 && (old.stageID == 5 || old.stageID == 11)) && (current.objectiveID == 0 || current.objectiveID == 1 || current.objectiveID == 2)))
 	||

--- a/BRC.asl
+++ b/BRC.asl
@@ -204,7 +204,7 @@ split
 	if((vars.gameMode == 1) 	&&
 	(settings["prologueAny"] 	&& 	(current.stageID == 5 && old.stageID == 8))
 	||
-	(settings["hideoutEscape"]	&&	((current.stageID == 5 && (current.loading && !old.loading)) && current.objectiveID == 0))
+	(settings["hideoutEscape"]	&&	((current.stageID == 5 && !current.inCutscene && (current.loading && !old.loading)) && current.objectiveID == 0))
 	||
 	(settings["hideoutAny"]		&&	((current.stageID == 4 && (old.stageID == 5 || old.stageID == 11)) && (current.objectiveID == 0 || current.objectiveID == 1 || current.objectiveID == 2)))
 	||


### PR DESCRIPTION
Fixes Mataan Enter split by splitting on starting to load into a new area rather than splitting when its in the new area. Avoids splitting when loading into hideout or going to other areas, since you cannot leave hideout any other way with objective 0.